### PR TITLE
Added Claude Code Project skills

### DIFF
--- a/.cgcignore
+++ b/.cgcignore
@@ -1,0 +1,9 @@
+node_modules/
+.git/
+dist/
+build/
+__pycache__/
+*.pyc
+.venv/
+venv/
+.indexes/

--- a/.claude/commands/add-component.md
+++ b/.claude/commands/add-component.md
@@ -1,0 +1,25 @@
+Create a new React component following StrideTrack project conventions.
+
+Component name: $ARGUMENTS
+
+For the component "$ARGUMENTS":
+
+1. **Component file** — Create in the appropriate `frontend/src/components/` subdirectory
+   - Use TypeScript with proper prop type definitions
+   - Use TailwindCSS for styling
+   - Use named exports (not default exports)
+
+2. **Data fetching** — If the component needs data:
+   - Create a custom hook in `frontend/src/hooks/` following `*.hooks.ts` naming
+   - Use TanStack Query (`useQuery`, `useMutation`) for all server state
+   - Never use raw `fetch` or `useEffect` for data fetching
+
+3. **Form validation** — If the component has forms:
+   - Use Zod schemas for validation
+   - Use React Hook Form for form state management
+
+4. **Routing** — If this is a page component:
+   - Place in `frontend/src/pages/`
+   - Add route in the React Router configuration
+
+Check existing components in the same directory for patterns and conventions before creating.

--- a/.claude/commands/add-endpoint.md
+++ b/.claude/commands/add-endpoint.md
@@ -1,0 +1,34 @@
+Create a new backend API endpoint following the route → service → repository pattern.
+
+Resource name: $ARGUMENTS
+
+For the resource "$ARGUMENTS", create or update these files:
+
+1. **Schema** — `backend/app/schemas/$ARGUMENTS.py`
+   - Pydantic request/response models with full type annotations
+   - Follow existing schema patterns in the schemas directory
+
+2. **Repository** — `backend/app/repositories/${ARGUMENTS}_repository.py`
+   - Supabase database operations only
+   - No business logic, no HTTP concerns
+   - Follow existing repository patterns
+
+3. **Service** — `backend/app/services/${ARGUMENTS}_service.py`
+   - Business logic and error handling
+   - Call repository methods for DB access
+   - Raise appropriate exceptions from `backend/app/core/exceptions.py`
+
+4. **Routes** — `backend/app/routes/${ARGUMENTS}_routes.py`
+   - FastAPI route handlers
+   - Input validation only, delegate to service
+   - Proper HTTP status codes and response models
+
+5. **Register router** — Update `backend/app/api.py`
+   - Import and include the new router with appropriate prefix and tags
+
+6. **Unit tests** — `backend/tests/unit/test_${ARGUMENTS}.py`
+   - Test service functions with mocked repository
+   - Follow test-first skill: write tests before or alongside implementation
+   - Run `make unit-test` to verify
+
+Check existing files in each directory for reference patterns before creating new ones.

--- a/.claude/commands/fix-lint.md
+++ b/.claude/commands/fix-lint.md
@@ -1,0 +1,7 @@
+Fix all linting and formatting issues across the entire project.
+
+Steps:
+1. Run `make format` to auto-fix what can be auto-fixed
+2. Run `make check-format` to verify everything passes
+3. If check-format still fails, manually fix the remaining issues
+4. Run `make check-format` again to confirm all issues are resolved

--- a/.claude/hooks/format-edited.mjs
+++ b/.claude/hooks/format-edited.mjs
@@ -1,0 +1,14 @@
+import { execSync } from "child_process";
+
+let input = "";
+process.stdin.on("data", (d) => (input += d));
+process.stdin.on("end", () => {
+  const data = JSON.parse(input);
+  const fp = data?.tool_input?.file_path ?? "";
+
+  if (fp.includes("/backend/")) {
+    execSync("make format-backend", { stdio: "inherit" });
+  } else if (fp.includes("/frontend/")) {
+    execSync("make format-frontend", { stdio: "inherit" });
+  }
+});

--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -1,0 +1,10 @@
+## Backend Rules
+
+- Always use type annotations on all function parameters and return types (Ruff ANN rules enforced)
+- Use Pydantic models for all request/response schemas
+- Never put business logic in route handlers — delegate to services
+- Never put HTTP concerns in repositories — they only interact with Supabase
+- Use `backend/app/core/config.py` (Settings class) for all environment variables
+- Ruff config is in `backend/pyproject.toml` — do not override inline
+- Use `uv` as the package manager (not pip directly)
+- Python version is pinned to 3.13.9 (see `backend/.python-version`)

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -1,0 +1,10 @@
+## Frontend Rules
+
+- Use Zod schemas for all form validation and API response parsing
+- Use TanStack Query for all server state — no manual fetch/useEffect patterns for data fetching
+- Use React Router for navigation
+- Use TailwindCSS for styling — reference `frontend/tailwind.config.js` for theme values
+- Use Bun as the package manager (not npm or yarn)
+- File naming conventions: `*.hooks.ts` for hooks, `*.service.ts` for services
+- Prefer named exports over default exports
+- ESLint config is in `frontend/eslint.config.js`, Prettier config in `frontend/.prettierrc`

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,12 @@
+## Testing Rules
+
+- Every new backend service function must have a corresponding unit test
+- Bug fixes must include a regression test that reproduces the bug
+- Unit tests go in `backend/tests/unit/` — these run without Supabase
+- Integration tests go in `backend/tests/integration/` — these require `make up` first
+- Test file naming: `test_{feature}.py`
+- Run unit tests: `make unit-test`
+- Run integration tests: `make int-test`
+- Run all tests: `make test`
+- Tests should verify behavior, not implementation details
+- Mock only external boundaries (Supabase client, external APIs), not internal functions

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,45 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(make check-format*)",
+      "Bash(make format*)",
+      "Bash(make unit-test*)",
+      "Bash(bun install*)",
+      "Bash(cd backend && uv run*)",
+      "Bash(cd frontend && bun run*)"
+    ],
+    "deny": [
+      "Bash(git push*)",
+      "Bash(make db-migrate*)",
+      "Bash(make clean*)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/format-edited.mjs"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "make check-format 2>&1 | tail -30"
+          },
+          {
+            "type": "command",
+            "command": "make unit-test 2>&1 | tail -40"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: code-review
+description: Self-review checklist to run before considering implementation work complete. Use before finishing a feature, after all tests pass, before committing.
+---
+
+# Code Review Skill
+
+> Adapted from [obra/superpowers-skills](https://github.com/obra/superpowers-skills) — code-reviewer standards. Customized for StrideTrack as a self-review checklist instead of subagent dispatch.
+
+## When to Use
+
+Run this checklist:
+
+- Before considering a feature implementation complete
+- After all tests pass but before committing
+- When you've made changes across multiple files
+- Before creating a pull request
+
+## Self-Review Checklist
+
+Go through each section. For any issue found, categorize it:
+
+- **Critical:** Bugs, security vulnerabilities, data loss risks — fix immediately
+- **Important:** Architectural problems, missing tests, type safety gaps — fix before proceeding
+- **Minor:** Style issues, naming improvements — note but don't block on these
+
+### 1. Code Quality
+
+- [ ] Functions have clear, single responsibilities
+- [ ] No duplicated logic that should be extracted
+- [ ] Error handling is appropriate (not swallowed, not over-caught)
+- [ ] Type annotations present on all function params and return types
+- [ ] No hardcoded values that should be in config (`backend/app/core/config.py`)
+
+### 2. Architecture (StrideTrack-specific)
+
+- [ ] Routes only validate input and call services — no business logic
+- [ ] Services contain business logic and error handling — no direct DB access
+- [ ] Repositories only perform Supabase operations — no HTTP concerns
+- [ ] Pydantic models used for all request/response schemas
+- [ ] Frontend uses TanStack Query for data fetching (no raw fetch/useEffect)
+- [ ] Frontend uses Zod for form validation
+
+### 3. Testing
+
+- [ ] New backend service functions have unit tests
+- [ ] Bug fixes include a regression test
+- [ ] Tests verify behavior, not implementation details
+- [ ] `make unit-test` passes
+- [ ] `make check-format` passes
+
+### 4. Security & Production Readiness
+
+- [ ] No secrets or credentials in code
+- [ ] User input is validated before use
+- [ ] No SQL injection vectors (using Supabase client properly)
+- [ ] No sensitive data logged or exposed in error messages
+
+## Issue Reporting Format
+
+When reporting issues found during review, use:
+
+```
+[Critical/Important/Minor] file_path:line_number
+Description of the issue
+WHY this matters: [explanation]
+```
+
+Always explain **why** something is an issue, not just what to change.

--- a/.claude/skills/debugging/SKILL.md
+++ b/.claude/skills/debugging/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: systematic-debugging
+description: Structured approach to finding and fixing bugs through root cause investigation before applying fixes. Use when encountering errors, test failures, or unexpected behavior.
+---
+
+# Systematic Debugging Skill
+
+> Adapted from [obra/superpowers-skills](https://github.com/obra/superpowers-skills) — systematic-debugging and root-cause-tracing skills. Customized for StrideTrack with lighter enforcement while keeping the core methodology.
+
+## Core Principle
+
+**NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST.**
+
+When the root cause is obvious and the fix is clearly correct, a quick fix is fine. But when the cause is unclear, or a fix attempt has already failed, follow the structured process below.
+
+## When to Use the Full Process
+
+- Error you haven't seen before
+- Test failing for unclear reasons
+- A "quick fix" didn't work
+- Multiple related failures
+- Intermittent/flaky behavior
+
+## Phase 1: Root Cause Investigation
+
+Before writing any fix:
+
+1. **Read the full error** — stack trace, error message, file and line number
+2. **Reproduce consistently** — find the exact steps or test that triggers it
+3. **Check recent changes** — what was modified since this last worked? (`git diff`, `git log`)
+4. **Gather evidence** — add temporary logging, check variable values, trace data flow
+5. **Trace backward** — follow the error back through the call chain to find the original trigger
+
+### Tracing Backward
+
+Start at the symptom and ask "what called this?" repeatedly:
+
+- Symptom → immediate cause → what called this → what provided bad data → **root cause**
+
+Don't stop at the first thing that looks wrong. Keep tracing until you find where the incorrect state was **first introduced**.
+
+## Phase 2: Pattern Analysis
+
+- Find a working example of similar code in the codebase
+- Compare the working and broken versions systematically
+- Identify the specific difference that causes the failure
+- Check if the same pattern appears elsewhere (might be multiple instances of the same bug)
+
+## Phase 3: Hypothesis and Testing
+
+- Form a specific hypothesis: "The bug is caused by X because Y"
+- Test one variable at a time — don't make multiple changes simultaneously
+- Verify your hypothesis before writing the fix
+
+## Phase 4: Implementation
+
+1. **Write a failing test** that reproduces the bug (test-first skill)
+2. **Implement the minimal fix** — change as little as possible
+3. **Verify the fix** — run `make unit-test` and any related tests
+4. **Check for collateral damage** — did the fix break anything else?
+
+## Escalation Rule
+
+**After 3+ failed fix attempts:** Stop. Step back and evaluate:
+
+- Is the architecture itself flawed?
+- Are you fixing the wrong layer? (route vs service vs repository)
+- Do you need to understand more context before proceeding?
+- Should you ask the user for clarification?
+
+Do not keep applying patches to the same area. If three attempts haven't worked, the problem is likely different from what you think.
+
+## Red Flags
+
+Watch for these signs that you're skipping investigation:
+
+- "Let me just try..." without understanding the cause
+- Making multiple changes at once
+- Fixing a symptom rather than the root cause
+- "It works now" without understanding why

--- a/.claude/skills/planning/SKILL.md
+++ b/.claude/skills/planning/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: planning
+description: Structured approach to understanding requirements and planning implementation before writing code. Use when starting a new feature, significant refactor, or multi-file change.
+---
+
+# Planning Skill
+
+> Adapted from [obra/superpowers-skills](https://github.com/obra/superpowers-skills) — brainstorming and writing-plans skills. Customized for StrideTrack with lighter enforcement and project-specific patterns.
+
+## When to Use
+
+- **Use full planning:** New features, multi-file changes, architectural decisions, new API endpoints
+- **Skip to implementation:** Single-file fixes, config changes, styling updates, documentation edits, typo fixes
+
+## Phase 1: Understanding
+
+Ask clarifying questions before writing any code. One question at a time — do not overwhelm with a wall of questions.
+
+Focus on:
+
+- **Purpose:** What problem does this solve? Who is the user?
+- **Constraints:** Performance requirements? Backward compatibility? Timeline?
+- **Success criteria:** How will we know this works correctly?
+- **Scope:** What is explicitly NOT in scope?
+
+If requirements are already clear and well-scoped, acknowledge and move to Phase 2.
+
+## Phase 2: Exploration
+
+Present 2-3 different approaches with trade-offs. Keep each approach description to 200-300 words. Include:
+
+- Architecture overview
+- Which existing files/patterns to reuse
+- Pros and cons
+- Estimated complexity
+
+For StrideTrack features, always consider:
+
+- Does this need a new route → service → repository chain?
+- Does this touch existing Supabase tables or need a migration?
+- Does this affect both frontend and backend?
+
+Get explicit approval on the chosen approach before proceeding.
+
+## Phase 3: Planning
+
+Break work into bite-sized tasks (2-5 minutes each). Each task must include:
+
+- **Exact file paths** to create or modify
+- **What to implement** in concrete terms
+- **How to verify** (which test to write, which make command to run)
+
+### Plan Template
+
+```markdown
+## Feature: [name]
+
+### Goal
+
+[One sentence describing the outcome]
+
+### Tasks
+
+#### 1. [Task name]
+
+- Files: `backend/app/services/example_service.py`, `backend/tests/unit/test_example.py`
+- Do: [Specific implementation details]
+- Verify: `make unit-test`
+
+#### 2. [Task name]
+
+...
+```
+
+Plans assume the reader has zero context about the codebase. Include file paths, function names, and references to existing patterns.
+
+## Phase 4: Execution
+
+Implement one task at a time. After each task:
+
+1. Run the verification step from the plan
+2. If it fails, fix before moving on
+3. If the plan needs adjustment based on what you learned, update it
+
+The hooks will automatically run `make check-format` and `make unit-test` at the end of each turn.

--- a/.claude/skills/test-first/SKILL.md
+++ b/.claude/skills/test-first/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: test-first
+description: Write tests before implementation for new backend logic, following red-green-refactor methodology. Use when creating new service functions, repository methods, or fixing bugs.
+---
+
+# Test-First Development Skill
+
+> Adapted from [obra/superpowers-skills](https://github.com/obra/superpowers-skills) — test-driven-development and testing-anti-patterns skills. Customized for StrideTrack with scope-based enforcement (not universal TDD) and no code deletion.
+
+## Scope-Based Enforcement
+
+### Required TDD (write tests FIRST)
+- New backend service functions (`backend/app/services/`)
+- New repository methods (`backend/app/repositories/`)
+- Bug fixes (reproduce the bug as a failing test first)
+- New utility functions (`backend/app/core/`)
+
+### Tests Encouraged (write tests, but implementation-first is OK)
+- Frontend components and hooks
+- API route handlers (`backend/app/routes/`)
+- Complex UI interactions
+
+### No TDD Needed
+- Config files, environment setup
+- Styling and CSS changes
+- Documentation and README updates
+- Database migrations
+- Simple one-line fixes where the change is obvious
+
+## The Red-Green-Refactor Cycle
+
+For tasks requiring TDD:
+
+### 1. RED — Write a Failing Test
+
+Write one focused test per behavior. The test should:
+- Test a single, specific behavior
+- Have a descriptive name explaining what it verifies
+- Use arrange-act-assert structure
+- Live in `backend/tests/unit/` (no Supabase needed) or `backend/tests/integration/`
+
+Run `make unit-test` and **verify the test fails**. If it passes without implementation, the test is not testing the right thing.
+
+### 2. GREEN — Write Minimal Implementation
+
+Write the **simplest code** that makes the test pass. No more, no less.
+- Do not add features the test does not require
+- Do not optimize prematurely
+- YAGNI — You Aren't Gonna Need It
+
+Run `make unit-test` and verify the test passes.
+
+### 3. REFACTOR — Clean Up
+
+With passing tests as your safety net:
+- Remove duplication
+- Improve naming
+- Simplify logic
+- Ensure the code follows StrideTrack patterns (route → service → repository)
+
+Run `make unit-test` again to verify nothing broke.
+
+## For Bug Fixes
+
+1. **Write a failing test** that reproduces the exact bug
+2. Verify the test fails in the way the bug manifests
+3. Implement the minimal fix
+4. Verify the test passes
+5. Check that no existing tests broke
+
+## If You Wrote Code Before Tests
+
+If you find yourself with implementation but no tests: **pause**. Write the tests now before proceeding to the next task. Do not move on until tests exist for the new logic.
+
+## Testing Anti-Patterns to Avoid
+
+These patterns create tests that pass but don't actually verify correct behavior:
+
+### Never Test Mock Behavior
+- **Wrong:** Assert that a mock was called with specific arguments
+- **Right:** Test that the actual function produces the correct output given specific input
+
+### Never Add Test-Only Methods to Production Code
+- **Wrong:** Adding a `get_internal_state()` method just for test assertions
+- **Right:** Test through the public API; use test utilities for setup
+
+### Never Mock Without Understanding Dependencies
+- **Wrong:** Mock everything the function touches to isolate it
+- **Right:** Understand what the function actually depends on; mock only external boundaries (Supabase client, external APIs)
+
+## StrideTrack Test Conventions
+
+- Unit tests: `backend/tests/unit/test_{feature}.py`
+- Integration tests: `backend/tests/integration/test_{feature}.py`
+- Run unit tests: `make unit-test` (fast, no Supabase)
+- Run integration tests: `make int-test` (requires `make up`)
+- Run all: `make test`

--- a/.gitignore
+++ b/.gitignore
@@ -237,7 +237,6 @@ lerna-debug.log*
 # Mise
 mise.toml
 
-# Claude Code
-CLAUDE.md
+# Claude Code (personal/local only)
 .mcp.json
-.cgcignore
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# StrideTrack
+
+## Tech Stack
+
+- **Frontend:** Bun + React 19 / Vite + TypeScript + TailwindCSS
+- **Backend:** Python 3.13 + FastAPI + Pydantic
+- **Database:** Supabase (Postgres + Auth)
+- **Containerized:** Docker Compose
+- **Backend tooling:** uv (package manager), Ruff (linter/formatter)
+- **Frontend tooling:** ESLint (linter), Prettier (formatter)
+- **Observability:** OpenTelemetry + Jaeger
+
+## Architecture
+
+Backend follows **route → service → repository** pattern:
+
+- `backend/app/routes/` — Request validation only, delegates to services
+- `backend/app/services/` — Business logic, error handling
+- `backend/app/repositories/` — Database operations only (Supabase client)
+- `backend/app/core/` — Settings, auth, config, exceptions
+- `backend/tests/unit/` — Unit tests (no Supabase required)
+- `backend/tests/integration/` — Integration tests (requires running Supabase)
+
+Frontend:
+
+- `frontend/src/pages/` — Page components (React Router)
+- `frontend/src/components/` — Reusable UI components
+- `frontend/src/hooks/` — Custom hooks (`*.hooks.ts`)
+- `frontend/src/context/` — React Context providers
+- `frontend/src/lib/` — Utilities, API client, config
+
+## Development Commands
+
+All commands via Makefile in project root:
+
+- `make check-format` — Check linting + formatting (backend + frontend)
+- `make format` — Auto-fix formatting issues
+- `make unit-test` — Run backend unit tests (no Supabase needed)
+- `make int-test` — Integration tests (requires `make up` first)
+- `make build` — Build Docker containers
+- `make up` / `make down` — Start/stop all services
+- `make init` — Initialize project (check deps + setup env files)
+
+## Coding Standards
+
+### Python
+
+- Pydantic models for all request/response schemas
+- Ruff for linting and formatting (config in `backend/pyproject.toml`)
+- Type annotations on all function parameters and return types
+- Central `backend/app/core/config.py` for all environment variables
+
+### TypeScript
+
+- Zod schemas for runtime validation
+- TanStack Query for all server state (no manual fetch/useEffect)
+- React Router for navigation
+- File naming: `*.hooks.ts`, `*.service.ts`
+- TailwindCSS for styling
+
+### General
+
+- Strong typing everywhere (params, returns, variables)
+- Descriptive, extension-based file naming
+- No secrets or `.env` files in commits
+
+## Git Workflow
+
+- **NOT auto-approved:** `git push`, production deploys, DB migrations
+- Always verify `make check-format` and `make unit-test` pass before committing

--- a/CLAUDE_SETUP_GUIDE.md
+++ b/CLAUDE_SETUP_GUIDE.md
@@ -1,0 +1,136 @@
+# Claude Code Setup Guide for StrideTrack
+
+This guide explains how Claude Code is configured in this repository and how to use it effectively.
+
+## Prerequisites
+
+Make sure you have these installed (same as normal development):
+
+- **Node.js** — required for cross-platform hooks
+- **uv** — Python package manager (backend)
+- **Bun** — JavaScript runtime and package manager (frontend)
+- **Python 3.13.9** — backend runtime
+
+Run `make check-deps` to verify everything is installed.
+
+## What's Configured
+
+### Automatic Hooks
+
+Hooks run automatically — no setup required. They're defined in `.claude/settings.json`.
+
+| When | What Runs | Purpose |
+|------|-----------|---------|
+| After every file edit | `make format-backend` or `make format-frontend` | Auto-fixes formatting for the file you just changed |
+| End of every turn | `make check-format` | Verifies all linting and formatting passes |
+| End of every turn | `make unit-test` | Runs backend unit tests to catch regressions |
+
+If a hook fails, Claude sees the failure output and will attempt to fix the issue.
+
+### Permissions
+
+These commands are **auto-approved** (Claude can run without asking):
+- `make check-format`, `make format`, `make unit-test`
+- `bun install`, `uv run`, `bun run`
+
+These commands are **blocked** (Claude cannot run):
+- `git push`
+- `make db-migrate`
+- `make clean`
+
+Everything else (including `git commit`) requires your approval.
+
+### Custom Skills
+
+Skills are prompting strategies that activate based on the task at hand. They live in `.claude/skills/`.
+
+| Skill | When It Activates | What It Does |
+|-------|-------------------|--------------|
+| **Planning** | New features, multi-file changes | Asks clarifying questions, explores approaches, breaks work into tasks |
+| **Test-First** | New service functions, bug fixes | Encourages writing tests before implementation (red-green-refactor) |
+| **Code Review** | Before finishing work | Self-review checklist for quality, architecture, and testing |
+| **Debugging** | Errors, test failures | Structured root cause investigation before applying fixes |
+
+Skills are guidelines, not hard blockers. They're adapted from the [Superpowers](https://github.com/obra/superpowers-skills) framework with lighter enforcement.
+
+### Slash Commands
+
+| Command | Usage | Purpose |
+|---------|-------|---------|
+| `/fix-lint` | `/fix-lint` | Auto-fix all linting and formatting issues |
+| `/add-endpoint` | `/add-endpoint athlete` | Scaffold a new backend endpoint (route + service + repo + tests) |
+| `/add-component` | `/add-component WorkoutCard` | Scaffold a new React component following conventions |
+
+### Rules
+
+Rules in `.claude/rules/` are auto-loaded into every conversation:
+- `backend.md` — Python/FastAPI coding standards
+- `frontend.md` — React/TypeScript conventions
+- `testing.md` — Testing requirements and locations
+
+## Personal Customization
+
+To override settings for your local environment, edit `.claude/settings.local.json` (gitignored).
+
+Example — adding MCP server permissions:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "mcp__my_tool__my_action"
+    ]
+  }
+}
+```
+
+Your local settings merge with the team settings. You cannot override team `deny` rules.
+
+## Troubleshooting
+
+### Hook fails with "command not found"
+
+Make sure `uv`, `bun`, and `node` are installed and on your PATH. Run `make check-deps` to verify.
+
+### Format hook fails on frontend
+
+Run `cd frontend && bun install` first. The formatter needs `node_modules` to be present.
+
+### Unit tests fail on hook
+
+The Stop hook runs `make unit-test` after every turn. If tests are failing for reasons unrelated to your current work, you can temporarily disable the hook in `.claude/settings.local.json`:
+
+```json
+{
+  "hooks": {
+    "Stop": []
+  }
+}
+```
+
+### MCP servers not working
+
+MCP configuration (`.mcp.json`) is gitignored because it references locally-installed tools. Each developer sets up their own MCP servers.
+
+## File Structure
+
+```
+.claude/
+├── settings.json          # Team config: hooks, permissions (committed)
+├── settings.local.json    # Personal overrides (gitignored)
+├── hooks/
+│   └── format-edited.mjs  # Cross-platform format hook (Node.js)
+├── skills/
+│   ├── planning/SKILL.md
+│   ├── test-first/SKILL.md
+│   ├── code-review/SKILL.md
+│   └── debugging/SKILL.md
+├── commands/
+│   ├── fix-lint.md
+│   ├── add-endpoint.md
+│   └── add-component.md
+└── rules/
+    ├── backend.md
+    ├── frontend.md
+    └── testing.md
+```


### PR DESCRIPTION
## Summary
<!-- Put issue number after # -->
Closes #138 

**What changed:**
Added shared Claude Code project configuration: `CLAUDE.md` with project context, `.claude/` directory with rules, skills, commands, hooks, and settings. Updated `.gitignore` to track these shared files while keeping personal ones (`.mcp.json`, `.claude/settings.local.json`) ignored. Also added a `CLAUDE_SETUP_GUIDE.md` for onboarding and a `.cgcignore` for the code graph context tool.

**Why:**
Gives all team members a consistent Claude Code experience with project-aware rules (backend, frontend, testing), reusable slash commands (`/add-component`, `/add-endpoint`, `/fix-lint`), development skills (`/planning`, `/code-review`, `/debugging`, `/test-first`), and a format-on-edit hook — so Claude follows StrideTrack conventions out of the box.

**Technical decisions worth noting:**
- `.claude/settings.json` is shared (team defaults); `.claude/settings.local.json` stays gitignored for personal overrides.
- The `format-edited.mjs` hook auto-runs Ruff/Prettier on files Claude edits, catching formatting issues before they reach CI.
- Skills are structured as markdown prompts under `.claude/skills/` so they can evolve with the project without code changes.

> AI disclosure: `CLAUDE.md`, rules, skills, commands, hooks, settings, and setup guide were AI-assisted with human review and editing.

---

## Screenshot
<!-- Frontend changes only-->
N/A — no frontend changes.

## Notes
- Team members should run through `CLAUDE_SETUP_GUIDE.md` to set up their local MCP servers and `settings.local.json`.
- The shared settings grant permissions for common dev commands (make, bun, uv, docker, git, etc.) so approval prompts are minimal during normal workflows.
