### PR TITLE
Separate Visualizations into Accordion Sections

### DIFF
--- a/frontend/src/lib/runAnalysisVisualizations.ts
+++ b/frontend/src/lib/runAnalysisVisualizations.ts
@@ -34,6 +34,7 @@ import { FatigueIndexKPI } from "@/components/charts/bosco/FatigueIndexKPI";
 import { GctFlightChart } from "@/components/charts/bosco/GctFlightChart";
 import { JumpHeightChart } from "@/components/charts/bosco/JumpHeightChart";
 import { RsiChart } from "@/components/charts/bosco/RsiChart";
+import { ReactionTimeCard } from "@/components/charts/reaction-time/ReactionTimeCard";
 
 export type VisualizationConfig = ComponentType<ChartProps>;
 
@@ -58,7 +59,7 @@ const ASYMMETRY: ChartSection = {
 
 const PERFORMANCE: ChartSection = {
   label: "Performance",
-  charts: [RSIChart, GCTRangePieChart, TotalStepsKPI],
+  charts: [RSIChart, GCTRangePieChart, TotalStepsKPI, ReactionTimeCard],
 };
 
 // Event-type sections

--- a/frontend/src/lib/runAnalysisVisualizations.ts
+++ b/frontend/src/lib/runAnalysisVisualizations.ts
@@ -1,23 +1,29 @@
-import type { ComponentType } from "react";
 import type { ChartProps } from "@/types/chart.types";
-import { EventCategory } from "@/types/event.types";
 import type { EventTypeEnum } from "@/types/event.types";
+import { EventCategory } from "@/types/event.types";
+import type { ComponentType } from "react";
 
 // Universal charts
-import { GroundContactTimeChart } from "@/components/charts/universal/GroundContactChart";
 import { FlightTimeChart } from "@/components/charts/universal/FlightTimeChart";
-import { ReactionTimeCard } from "@/components/charts/reaction-time/ReactionTimeCard";
+import { FTAsymmetryKPI } from "@/components/charts/universal/FTAsymmetryKPI";
+import { GCTAsymmetryKPI } from "@/components/charts/universal/GCTAsymmetryKPI";
+import { GCTRangePieChart } from "@/components/charts/universal/GCTRangePieChart";
+import { GroundContactTimeChart } from "@/components/charts/universal/GroundContactChart";
+import { RSIChart } from "@/components/charts/universal/RSIChart";
+import { StepTimeChart } from "@/components/charts/universal/StepTimeChart";
+import { TotalStepsKPI } from "@/components/charts/universal/TotalStepsKPI";
 
 // Hurdle charts
 import { GctIncreaseChart } from "@/components/charts/hurdles/GctIncreaseChart";
 import { HurdleSplitChart } from "@/components/charts/hurdles/HurdleSplitChart";
+import { HurdleTimelineChart } from "@/components/charts/hurdles/HurdleTimelineChart";
 import { LandingGctChart } from "@/components/charts/hurdles/LandingGctChart";
-import { StepsBetweenHurdlesChart } from "@/components/charts/hurdles/StepsBetweenHurdlesChart";
-import { TakeoffFtChart } from "@/components/charts/hurdles/TakeoffFtChart";
-import { TakeoffGctChart } from "@/components/charts/hurdles/TakeoffGctChart";
 import { ProjectedFinishKPI } from "@/components/charts/hurdles/ProjectedFinishChart";
 import { ProjectedSplitChart } from "@/components/charts/hurdles/ProjectedSplitChart";
 import { SplitScoreChart } from "@/components/charts/hurdles/SplitScoreChart";
+import { StepsBetweenHurdlesChart } from "@/components/charts/hurdles/StepsBetweenHurdlesChart";
+import { TakeoffFtChart } from "@/components/charts/hurdles/TakeoffFtChart";
+import { TakeoffGctChart } from "@/components/charts/hurdles/TakeoffGctChart";
 
 // Sprint charts
 import { SprintDriftKPIs } from "@/components/charts/sprint/DriftKPI";
@@ -28,64 +34,103 @@ import { FatigueIndexKPI } from "@/components/charts/bosco/FatigueIndexKPI";
 import { GctFlightChart } from "@/components/charts/bosco/GctFlightChart";
 import { JumpHeightChart } from "@/components/charts/bosco/JumpHeightChart";
 import { RsiChart } from "@/components/charts/bosco/RsiChart";
-import { HurdleTimelineChart } from "@/components/charts/hurdles/HurdleTimelineChart";
-import { FTAsymmetryKPI } from "@/components/charts/universal/FTAsymmetryKPI";
-import { GCTAsymmetryKPI } from "@/components/charts/universal/GCTAsymmetryKPI";
-import { GCTRangePieChart } from "@/components/charts/universal/GCTRangePieChart";
-import { RSIChart } from "@/components/charts/universal/RSIChart";
-import { StepTimeChart } from "@/components/charts/universal/StepTimeChart";
-import { TotalStepsKPI } from "@/components/charts/universal/TotalStepsKPI";
 
 export type VisualizationConfig = ComponentType<ChartProps>;
 
-const DEFAULT_CHARTS: VisualizationConfig[] = [
-  GroundContactTimeChart,
-  FlightTimeChart,
-  FTAsymmetryKPI,
-  GCTAsymmetryKPI,
-  GCTRangePieChart,
-  RSIChart,
-  StepTimeChart,
-  TotalStepsKPI,
-  ReactionTimeCard,
-];
+export type ChartSection = {
+  label: string;
+  charts: VisualizationConfig[];
+  defaultExpanded?: boolean;
+};
 
-const visualizationsByEventType: Record<string, VisualizationConfig[]> = {
+// Reusable universal sections
+
+const CORE_TEMPORAL: ChartSection = {
+  label: "Core Temporal",
+  charts: [GroundContactTimeChart, FlightTimeChart, StepTimeChart],
+  defaultExpanded: true,
+};
+
+const ASYMMETRY: ChartSection = {
+  label: "Asymmetry & Balance",
+  charts: [GCTAsymmetryKPI, FTAsymmetryKPI],
+};
+
+const PERFORMANCE: ChartSection = {
+  label: "Performance",
+  charts: [RSIChart, GCTRangePieChart, TotalStepsKPI],
+};
+
+// Event-type sections
+
+const sectionsByEventType: Record<string, ChartSection[]> = {
   sprint: [
-    ...DEFAULT_CHARTS,
-    SprintDriftKPIs,
-    StepFrequencyChart,
-    SplitScoreChart,
+    CORE_TEMPORAL,
+    ASYMMETRY,
+    PERFORMANCE,
+    {
+      label: "Sprint-Specific",
+      charts: [SprintDriftKPIs, StepFrequencyChart, SplitScoreChart],
+    },
   ],
   hurdles: [
-    ...DEFAULT_CHARTS,
-    GctIncreaseChart,
-    HurdleSplitChart,
-    LandingGctChart,
-    StepsBetweenHurdlesChart,
-    TakeoffFtChart,
-    TakeoffGctChart,
-    SplitScoreChart,
-    ProjectedFinishKPI,
-    ProjectedSplitChart,
-    HurdleTimelineChart,
+    CORE_TEMPORAL,
+    ASYMMETRY,
+    PERFORMANCE,
+    {
+      label: "Hurdle-Specific",
+      charts: [
+        HurdleSplitChart,
+        StepsBetweenHurdlesChart,
+        TakeoffGctChart,
+        LandingGctChart,
+        TakeoffFtChart,
+        GctIncreaseChart,
+        SplitScoreChart,
+        HurdleTimelineChart,
+      ],
+    },
   ],
   hurdles_partial: [
-    ...DEFAULT_CHARTS,
-    GctIncreaseChart,
-    HurdleSplitChart,
-    LandingGctChart,
-    StepsBetweenHurdlesChart,
-    TakeoffFtChart,
-    TakeoffGctChart,
-    SplitScoreChart,
-    ReactionTimeCard,
-    ProjectedFinishKPI,
-    ProjectedSplitChart,
-    HurdleTimelineChart,
+    CORE_TEMPORAL,
+    ASYMMETRY,
+    PERFORMANCE,
+    {
+      label: "Hurdle-Specific",
+      charts: [
+        HurdleSplitChart,
+        StepsBetweenHurdlesChart,
+        TakeoffGctChart,
+        LandingGctChart,
+        TakeoffFtChart,
+        GctIncreaseChart,
+        SplitScoreChart,
+        HurdleTimelineChart,
+      ],
+    },
+    {
+      label: "Projected Performance",
+      charts: [ProjectedFinishKPI, ProjectedSplitChart],
+    },
   ],
-  bosco: [GctFlightChart, JumpHeightChart, RsiChart, FatigueIndexKPI],
+  bosco: [
+    {
+      label: "Jump Height",
+      charts: [JumpHeightChart],
+      defaultExpanded: true,
+    },
+    {
+      label: "Rhythm & Power",
+      charts: [GctFlightChart, RsiChart],
+    },
+    {
+      label: "Fatigue",
+      charts: [FatigueIndexKPI],
+    },
+  ],
 };
+
+// Lookup helpers
 
 export function getEventCategory(
   eventType: EventTypeEnum
@@ -96,13 +141,19 @@ export function getEventCategory(
   return null;
 }
 
-export function getChartsForEventType(
+const DEFAULT_SECTIONS: ChartSection[] = [
+  CORE_TEMPORAL,
+  ASYMMETRY,
+  PERFORMANCE,
+];
+
+export function getSectionsForEventType(
   eventType: EventTypeEnum
-): VisualizationConfig[] {
-  if (eventType in visualizationsByEventType) {
-    return visualizationsByEventType[eventType];
+): ChartSection[] {
+  if (eventType in sectionsByEventType) {
+    return sectionsByEventType[eventType];
   }
   const category = getEventCategory(eventType);
-  if (!category) return DEFAULT_CHARTS;
-  return visualizationsByEventType[category] ?? DEFAULT_CHARTS;
+  if (!category) return DEFAULT_SECTIONS;
+  return sectionsByEventType[category] ?? DEFAULT_SECTIONS;
 }

--- a/frontend/src/pages/RunAnalysisPage.tsx
+++ b/frontend/src/pages/RunAnalysisPage.tsx
@@ -1,7 +1,84 @@
-import { useParams, useNavigate } from "react-router-dom";
 import { useGetRunMeta } from "@/hooks/useRuns.hooks";
-import { getChartsForEventType } from "@/lib/runAnalysisVisualizations";
-import { ArrowLeft } from "lucide-react";
+import type { ChartSection } from "@/lib/runAnalysisVisualizations";
+import { getSectionsForEventType } from "@/lib/runAnalysisVisualizations";
+import { ArrowLeft, ChevronDown } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+
+function AccordionSection({
+  section,
+  runId,
+}: {
+  section: ChartSection;
+  runId: string;
+}) {
+  const [expanded, setExpanded] = useState(section.defaultExpanded ?? false);
+  const [shouldRender, setShouldRender] = useState(
+    section.defaultExpanded ?? false
+  );
+  const [contentHeight, setContentHeight] = useState<number>(0);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (expanded && contentRef.current) {
+      const updateHeight = () => {
+        setContentHeight(contentRef.current?.scrollHeight ?? 0);
+      };
+      updateHeight();
+      const observer = new ResizeObserver(updateHeight);
+      observer.observe(contentRef.current);
+      return () => observer.disconnect();
+    }
+  }, [expanded, shouldRender]);
+
+  const handleToggle = () => {
+    if (!expanded) {
+      setShouldRender(true);
+      requestAnimationFrame(() => setExpanded(true));
+    } else {
+      setExpanded(false);
+    }
+  };
+
+  const handleTransitionEnd = () => {
+    if (!expanded) {
+      setShouldRender(false);
+    }
+  };
+
+  return (
+    <div className="border border-border rounded-lg overflow-hidden">
+      <button
+        onClick={handleToggle}
+        className="flex w-full items-center justify-between px-4 py-4 text-base font-medium text-foreground hover:bg-muted/50 transition-colors"
+      >
+        {section.label}
+        <ChevronDown
+          className={`h-4 w-4 text-muted-foreground transition-transform duration-200 ${
+            expanded ? "rotate-180" : ""
+          }`}
+        />
+      </button>
+      <div
+        ref={contentRef}
+        onTransitionEnd={handleTransitionEnd}
+        className="transition-all duration-300 ease-in-out overflow-hidden"
+        style={{
+          maxHeight: expanded ? `${contentHeight}px` : "0px",
+          opacity: expanded ? 1 : 0,
+        }}
+      >
+        {shouldRender && (
+          <div className="flex flex-col gap-6 px-4 pb-4">
+            {section.charts.map((ChartComponent, i) => (
+              <ChartComponent key={i} runId={runId} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
 
 export default function RunAnalysisPage() {
   const { athleteId, runId } = useParams<{
@@ -11,36 +88,41 @@ export default function RunAnalysisPage() {
   const navigate = useNavigate();
 
   const { runMeta } = useGetRunMeta(runId);
-  const charts = runMeta?.event_type
-    ? getChartsForEventType(runMeta.event_type)
+  const sections = runMeta?.event_type
+    ? getSectionsForEventType(runMeta.event_type)
     : [];
 
   return (
     <div className="flex h-full flex-col pt-4">
-      <div className="mb-6">
+      <div className="mb-6 flex items-center gap-3">
         <button
           onClick={() => navigate(`/athletes/${athleteId}`)}
-          className="mb-4 flex items-center gap-1 text-sm text-muted-foreground"
+          className="flex items-center text-muted-foreground hover:text-foreground"
         >
           <ArrowLeft className="h-4 w-4" />
-          Back to Athlete
         </button>
-        <h2 className="text-xl font-bold text-foreground">Event Analysis</h2>
         {runMeta && (
-          <p className="text-sm text-muted-foreground mt-1">
-            {runMeta.event_type
-              .replace(/_/g, " ")
-              .replace(/\b\w/g, (c) => c.toUpperCase())}{" "}
-            · {new Date(runMeta.created_at).toLocaleDateString()}
+          <p className="text-sm text-muted-foreground">
+            <span className="font-semibold text-foreground">
+              {runMeta.event_type
+                .replace(/_/g, " ")
+                .replace(/\b\w/g, (c) => c.toUpperCase())}
+            </span>
+            {" · "}
+            {new Date(runMeta.created_at).toLocaleDateString()}
             {` · ${(runMeta.elapsed_ms / 1000).toFixed(2)}s`}
           </p>
         )}
       </div>
 
       {runId ? (
-        <div className="flex flex-1 flex-col gap-6">
-          {charts.map((ChartComponent, i) => (
-            <ChartComponent key={i} runId={runId} />
+        <div className="flex flex-1 flex-col gap-4">
+          {sections.map((section) => (
+            <AccordionSection
+              key={section.label}
+              section={section}
+              runId={runId}
+            />
           ))}
         </div>
       ) : (

--- a/frontend/src/pages/RunAnalysisPage.tsx
+++ b/frontend/src/pages/RunAnalysisPage.tsx
@@ -13,9 +13,6 @@ function AccordionSection({
   runId: string;
 }) {
   const [expanded, setExpanded] = useState(section.defaultExpanded ?? false);
-  const [shouldRender, setShouldRender] = useState(
-    section.defaultExpanded ?? false
-  );
   const [contentHeight, setContentHeight] = useState<number>(0);
   const contentRef = useRef<HTMLDivElement>(null);
 
@@ -29,27 +26,12 @@ function AccordionSection({
       observer.observe(contentRef.current);
       return () => observer.disconnect();
     }
-  }, [expanded, shouldRender]);
-
-  const handleToggle = () => {
-    if (!expanded) {
-      setShouldRender(true);
-      requestAnimationFrame(() => setExpanded(true));
-    } else {
-      setExpanded(false);
-    }
-  };
-
-  const handleTransitionEnd = () => {
-    if (!expanded) {
-      setShouldRender(false);
-    }
-  };
+  }, [expanded]);
 
   return (
     <div className="border border-border rounded-lg overflow-hidden">
       <button
-        onClick={handleToggle}
+        onClick={() => setExpanded(!expanded)}
         className="flex w-full items-center justify-between px-4 py-4 text-base font-medium text-foreground hover:bg-muted/50 transition-colors"
       >
         {section.label}
@@ -61,20 +43,17 @@ function AccordionSection({
       </button>
       <div
         ref={contentRef}
-        onTransitionEnd={handleTransitionEnd}
         className="transition-all duration-300 ease-in-out overflow-hidden"
         style={{
           maxHeight: expanded ? `${contentHeight}px` : "0px",
           opacity: expanded ? 1 : 0,
         }}
       >
-        {shouldRender && (
-          <div className="flex flex-col gap-6 px-4 pb-4">
-            {section.charts.map((ChartComponent, i) => (
-              <ChartComponent key={i} runId={runId} />
-            ))}
-          </div>
-        )}
+        <div className="flex flex-col gap-6 px-4 pb-4">
+          {section.charts.map((ChartComponent, i) => (
+            <ChartComponent key={i} runId={runId} />
+          ))}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Closes #153 


**What changed:**
Condensed the event analysis top bar by removing the page title and back button text, placing the back arrow and event info onto a single limne. Visualizations charts are now grouped into collapsible accordion sections instead of rendering as a flat list.

**Why:**
The visualizations page was cluttered and overwhelming for coaches with all charts stacked vertically with no organization. The top bar also wasted vertical space with a separate title. This should give the visualizations a cleaner feel and make things easier on the coaches.

**Technical decisions worth noting:**
- Changed the chart config from a flat config to a section of chart structures so each event type defines its own labeled, ordered sections.
- Charts stay mounted when collapsed so that they don't need to refetch data. Collapsing just hides them through a max-height transition.

> AI disclosure: Used to help with the accordion animation and logic.

---

## Screenshot
<img width="608" height="1299" alt="Screenshot 2026-04-12 161858" src="https://github.com/user-attachments/assets/87738d42-9178-427c-b776-dc4998b807d2" />
<img width="605" height="1298" alt="Screenshot 2026-04-12 161909" src="https://github.com/user-attachments/assets/66c46415-7d89-4497-81e2-b54db4a5b66e" />
<img width="604" height="1299" alt="Screenshot 2026-04-12 161925" src="https://github.com/user-attachments/assets/a8347bd4-3901-44a0-9f90-e9c4b112b966" />